### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy.yaml
+++ b/.github/workflows/test-deploy.yaml
@@ -7,6 +7,9 @@ on:
         # Review gh actions docs if you want to further define triggers, paths, etc
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+    contents: read
+
 jobs:
     test-deploy:
         name: Test deployment


### PR DESCRIPTION
Potential fix for [https://github.com/learnercraft/docugrammar/security/code-scanning/1](https://github.com/learnercraft/docugrammar/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the permissions for the `GITHUB_TOKEN`. Since the workflow only checks out the repository and installs dependencies, it only requires `contents: read` permissions. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
